### PR TITLE
Removed `cli` and `hardware-wallet` from build

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,4 +1,5 @@
 {
+  "_ethers_nobuild": true,
   "author": "Richard Moore <me@ricmoo.com>",
   "bin": {
     "ethers": "./lib/bin/ethers.js",

--- a/packages/hardware-wallets/package.json
+++ b/packages/hardware-wallets/package.json
@@ -1,4 +1,5 @@
 {
+  "_ethers_nobuild": true,
   "_ethers.alias": {
     "ledger-transport.js": "browser-ledger-transport.js"
   },


### PR DESCRIPTION
**Description**:

Removed the `cli` and `hardware-wallets` packages from the build. They should no longer be automatically added to `tsconfig.project.json`

**Related issue(s)**:

Fixes #63 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
