### PR TITLE
Fix: update-versions removes dependencies

### DIFF
--- a/misc/admin/lib/cmds/bump-versions.js
+++ b/misc/admin/lib/cmds/bump-versions.js
@@ -91,7 +91,7 @@ const utils_1 = require("../utils");
             const info = (0, utils_1.loadJson)(filename);
             Object.keys(info.dependencies).forEach((name) => {
                 const version = latestVersions[name];
-                if (name == null) {
+                if (name == null || !version) {
                     return;
                 }
                 info.dependencies[name] = version;

--- a/misc/admin/src.ts/cmds/bump-versions.ts
+++ b/misc/admin/src.ts/cmds/bump-versions.ts
@@ -76,7 +76,7 @@ import { loadJson, repeat, saveJson } from "../utils";
         const info = loadJson(filename);
         Object.keys(info.dependencies).forEach((name) => {
             const version = latestVersions[name];
-            if (name == null) { return; }
+            if (name == null || !version) { return; }
             info.dependencies[name] = version;
         });
         saveJson(filename, info);


### PR DESCRIPTION
**Description**:

`npm run update-versions` removes all dependencies that are not a package from the hethers project. This PR fixes that.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
